### PR TITLE
Fix project IDs and recent projects slider

### DIFF
--- a/src/app/_components/sliders/RecentProjects.jsx
+++ b/src/app/_components/sliders/RecentProjects.jsx
@@ -7,13 +7,14 @@ import { useState } from "react";
 import Data from "@data/sliders/recent-projects";
 
 const RecentProjectsSlider = () => {
+  const displayedItems = Data.items.slice(0, 5);
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const handleSlideChange = (swiper) => {
     setCurrentIndex(swiper.realIndex);
   };
 
-  const currentItem = Data.items[currentIndex];
+  const currentItem = displayedItems[currentIndex];
 
   return (
     <>
@@ -67,7 +68,7 @@ const RecentProjectsSlider = () => {
                   onSlideChange={handleSlideChange}
                   onInit={(swiper) => setCurrentIndex(swiper.realIndex)}
                 >
-                  {Data.items.map((item, key) => (
+                  {displayedItems.map((item, key) => (
                     <SwiperSlide
                       className="swiper-slide"
                       key={`illustration-slider-item-${key}`}

--- a/src/data/projects/data.json
+++ b/src/data/projects/data.json
@@ -1,7 +1,7 @@
 {
   "projects": [
     {
-      "id": 24,
+      "id": 1,
       "title": "Ringways - CAT3 Bury Lane Codicote Project",
       "category_slug": "architecture",
       "image": "/img/projects/223.jpg",
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "id": 23,
+      "id": 2,
       "title": "Ringways - CAT3 Hertford Town Centre Project",
       "category_slug": "architecture",
       "image": "/img/projects/222.jpg",
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "id": 0,
+      "id": 3,
       "title": "Ringways - External works - St John’s Road, Hertford Project",
       "category_slug": "architecture",
       "image": "/img/projects/111.jpg",
@@ -116,7 +116,7 @@
       ]
     },
     {
-      "id": 1,
+      "id": 4,
       "title": "Boundary Way, Hemel Hampstead",
       "category_slug": "architecture",
       "image": "/img/projects/0.png",
@@ -141,7 +141,7 @@
       ]
     },
     {
-      "id": 2,
+      "id": 5,
       "title": "Ringways - CAT3 Handside lane WGC",
       "category_slug": "architecture",
       "image": "/img/projects/1.jpg",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "id": 3,
+      "id": 6,
       "title": "Ringways - CAT Hadham Road, Bishops Stortford",
       "category_slug": "architecture",
       "image": "/img/projects/2.jpg",
@@ -243,7 +243,7 @@
       ]
     },
     {
-      "id": 4,
+      "id": 7,
       "title": "Ringways - TMZ St Albans 2",
       "category_slug": "architecture",
       "image": "/img/projects/3.jpg",
@@ -268,7 +268,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 8,
       "title": "Eurovia - Briar Way Drainage",
       "description": "The project involves the installation of new gullies, rebuilding of existing gullies, and the installation of channel kerbs to direct water flow away from nearby properties. Carriageway surfacing works will be carried out by Eurovia.",
       "category_slug": "architecture",
@@ -294,7 +294,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 9,
       "title": "Eurovia - Hight Street, Tring",
       "description": "This high street features a unique paving pattern at the junction hatch lines and distinctive clay pavers. BCL applied their expertise to carefully preserve the original design and faithfully recreate it during the reconstruction.",
       "category_slug": "architecture",
@@ -360,7 +360,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 10,
       "title": "Ringways - ITP 190015-1 Boundary Way, Hemel Hampstead",
       "category_slug": "architecture",
       "image": "/img/projects/14.png",
@@ -429,7 +429,7 @@
       ]
     },
     {
-      "id": 8,
+      "id": 11,
       "title": "ATF Jarman Park",
       "category_slug": "project-1",
       "image": "/img/projects/1.png",
@@ -482,7 +482,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 12,
       "title": "Builders Depot New Southgate",
       "category_slug": "architecture",
       "image": "/img/projects/2.png",
@@ -515,7 +515,7 @@
       ]
     },
     {
-      "id": 10,
+      "id": 13,
       "title": "Eurovia - Cherry Three Lane Project",
       "category_slug": "architecture",
       "image": "/img/covers/3.jpg",
@@ -572,7 +572,7 @@
       ]
     },
     {
-      "id": 11,
+      "id": 14,
       "title": "Eurovia - High Street, Tring Project",
       "category_slug": "architecture",
       "image": "/img/covers/4.jpg",
@@ -697,7 +697,7 @@
       ]
     },
     {
-      "id": 12,
+      "id": 15,
       "title": "Ringways - ITP Bearton Road, Hitchin Project",
       "category_slug": "architecture",
       "image": "/img/covers/5.jpg",
@@ -754,7 +754,7 @@
       ]
     },
     {
-      "id": 13,
+      "id": 16,
       "title": "Ringways - ATF Marlborough St. Albans Project",
       "category_slug": "architecture",
       "image": "/img/covers/6.jpg",
@@ -835,7 +835,7 @@
       ]
     },
     {
-      "id": 14,
+      "id": 17,
       "title": "Hemel Hampstead Project",
       "category_slug": "architecture",
       "image": "/img/covers/7.jpg",
@@ -888,7 +888,7 @@
       ]
     },
     {
-      "id": 15,
+      "id": 18,
       "title": "Stevenage Project",
       "category_slug": "architecture",
       "image": "/img/projects/8.png",
@@ -953,7 +953,7 @@
       ]
     },
     {
-      "id": 16,
+      "id": 19,
       "title": "Welwyn Garden City",
       "category_slug": "architecture",
       "image": "/img/covers/8.jpg",
@@ -994,7 +994,7 @@
       ]
     },
     {
-      "id": 17,
+      "id": 20,
       "title": "CAT 3 Washington Ave Hemel Hampstead - Ringway Project",
       "category_slug": "architecture",
       "image": "/img/projects/13.png",
@@ -1047,7 +1047,7 @@
       ]
     },
     {
-      "id": 18,
+      "id": 21,
       "title": "Eurovia - Bark Way, Royston Project",
       "category_slug": "architecture",
       "image": "/img/projects/bute/2/2.jpg",
@@ -1072,7 +1072,7 @@
       ]
     },
     {
-      "id": 19,
+      "id": 22,
       "title": "Ringways - The Woods, Northwood Project",
       "category_slug": "architecture",
       "image": "/img/projects/bute/5/2.jpg",
@@ -1153,7 +1153,7 @@
       ]
     },
     {
-      "id": 20,
+      "id": 23,
       "title": "Ringways - CAT 3 Howlands, Welwyn Garden City Project",
       "category_slug": "architecture",
       "image": "/img/projects/bute/6/2.jpg",
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "id": 21,
+      "id": 24,
       "title": "Work Gallery 1",
       "category_slug": "architecture",
       "image": "/img/covers/9.jpg",
@@ -1243,7 +1243,7 @@
       ]
     },
     {
-      "id": 22,
+      "id": 25,
       "title": "Work Gallery 2",
       "category_slug": "architecture",
       "image": "/img/covers/10.jpg",

--- a/src/data/sliders/recent-projects.json
+++ b/src/data/sliders/recent-projects.json
@@ -24,13 +24,13 @@
   "items": [
     {
       "title": "Ringways - Boundary Way, Hemel Hampstead Project",
-      "image": "/img/projects/14.PNG",
+      "image": "/img/projects/14.png",
       "subtitle": "ONGOING",
       "alt": "image"
     },
     {
       "title": "Ringways - ITP 190015-1 Boundary Way, Hemel Hampstead Project",
-      "image": "/img/projects/14.PNG",
+      "image": "/img/projects/14.png",
       "subtitle": "ONGOING",
       "alt": "image"
     },


### PR DESCRIPTION
## Summary
- renumber project IDs sequentially
- show only five projects in RecentProjects slider
- fix recent projects image path

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687cf11a0bb48326abda03cbcc37b22b