### PR TITLE
Reverse projects display order

### DIFF
--- a/src/app/_components/sliders/RecentProjects.jsx
+++ b/src/app/_components/sliders/RecentProjects.jsx
@@ -5,9 +5,12 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { useState } from "react";
 
 import Data from "@data/sliders/recent-projects";
+import ProjectsData from "@data/projects/data.json";
 
 const RecentProjectsSlider = () => {
-  const displayedItems = Data.items.slice(0, 5);
+  const displayedItems = [...ProjectsData.projects]
+    .sort((a, b) => b.id - a.id)
+    .slice(0, 5);
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const handleSlideChange = (swiper) => {
@@ -79,7 +82,7 @@ const RecentProjectsSlider = () => {
                         data-swiper-parallax-scale="1.3"
                       >
                         <div className="mil-image-frame">
-                          <img src={item.image} alt={item.alt} />
+                          <img src={item.image} alt={item.alt || item.title} />
                         </div>
                       </div>
                     </SwiperSlide>

--- a/src/app/content/ProjectsPageContent.jsx
+++ b/src/app/content/ProjectsPageContent.jsx
@@ -10,7 +10,8 @@ const ProjectsMasonry = dynamic(() => import("@components/ProjectsMasonry"), {
 });
 
 function ProjectsPageContent() {
-  const projects = data.projects; // Use the projects data from data.json
+  // Display projects in descending order so newest items appear first
+  const projects = [...data.projects].sort((a, b) => b.id - a.id);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- sort projects in descending ID order
- show last five projects as the recent projects slider source

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6880f13330c48326bcae837f93e1da5f